### PR TITLE
Core: preserve first_row_id in rewrite manifest copy

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -497,6 +497,7 @@ public class ManifestFiles {
     // for a rewritten manifest all snapshot ids should be set. use empty metadata to throw an
     // exception if it is not
     InheritableMetadata inheritableMetadata = InheritableMetadataFactory.empty();
+    // rewrite manifests are transient; null manifest-level first_row_id must not clear file IDs
     try (ManifestReader<DataFile> reader =
         new ManifestReader<>(
             toCopy,

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -499,7 +499,13 @@ public class ManifestFiles {
     InheritableMetadata inheritableMetadata = InheritableMetadataFactory.empty();
     try (ManifestReader<DataFile> reader =
         new ManifestReader<>(
-            toCopy, specId, specsById, inheritableMetadata, firstRowId, FileType.DATA_FILES)) {
+            toCopy,
+            specId,
+            specsById,
+            inheritableMetadata,
+            firstRowId,
+            false /* isCommitted */,
+            FileType.DATA_FILES)) {
       return copyManifestInternal(
           formatVersion,
           firstRowId,

--- a/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
@@ -828,17 +828,24 @@ public class TestRowLineageAssignment {
             PartitionSpec.unpartitioned(),
             manifestOutput,
             -1L);
-    try {
-      writer.existing(
+    try (ManifestWriter<DataFile> closeableWriter = writer) {
+      closeableWriter.existing(
           fileWithRowId, appendSnapshot.snapshotId(), appendSnapshot.sequenceNumber(), null);
-    } finally {
-      writer.close();
+    }
+
+    ManifestFile rewriteManifest = writer.toManifestFile();
+    assertThat(rewriteManifest.firstRowId()).isNull();
+    assertThat(rewriteManifest.snapshotId()).isEqualTo(-1L);
+
+    try (ManifestReader<DataFile> reader =
+        ManifestFiles.read(rewriteManifest, table.io(), table.specs(), false /* isCommitted */)) {
+      assertThat(Iterables.getOnlyElement(reader).firstRowId()).isEqualTo(0L);
     }
 
     table
         .rewriteManifests()
         .deleteManifest(originalManifest)
-        .addManifest(writer.toManifestFile())
+        .addManifest(rewriteManifest)
         .commit();
 
     ManifestFile committedManifest =

--- a/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
@@ -806,6 +807,43 @@ public class TestRowLineageAssignment {
         manifest,
         FILE_A.recordCount() + FILE_B.recordCount(), // FILE_C gets 225
         FILE_A.recordCount()); // FILE_B must retain its original firstRowId (125)
+  }
+
+  @Test
+  public void testRewriteManifestsAddManifestPreservesExistingFileFirstRowIds() throws IOException {
+    table.newAppend().appendFile(FILE_A).commit();
+
+    Snapshot appendSnapshot = table.currentSnapshot();
+    ManifestFile originalManifest =
+        Iterables.getOnlyElement(appendSnapshot.dataManifests(table.io()));
+    checkDataFileAssignment(table, originalManifest, 0L);
+
+    DataFile fileWithRowId =
+        DataFiles.builder(PartitionSpec.unpartitioned()).copy(FILE_A).withFirstRowId(0L).build();
+    OutputFile manifestOutput =
+        table.io().newOutputFile(new File(location, "rewrite-manifest.avro").getAbsolutePath());
+    ManifestWriter<DataFile> writer =
+        ManifestFiles.write(
+            table.operations().current().formatVersion(),
+            PartitionSpec.unpartitioned(),
+            manifestOutput,
+            -1L);
+    try {
+      writer.existing(
+          fileWithRowId, appendSnapshot.snapshotId(), appendSnapshot.sequenceNumber(), null);
+    } finally {
+      writer.close();
+    }
+
+    table
+        .rewriteManifests()
+        .deleteManifest(originalManifest)
+        .addManifest(writer.toManifestFile())
+        .commit();
+
+    ManifestFile committedManifest =
+        Iterables.getOnlyElement(table.currentSnapshot().dataManifests(table.io()));
+    checkDataFileAssignment(table, committedManifest, 0L);
   }
 
   private static ManifestContent content(int ordinal) {

--- a/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
@@ -811,6 +811,9 @@ public class TestRowLineageAssignment {
 
   @Test
   public void testRewriteManifestsAddManifestPreservesExistingFileFirstRowIds() throws IOException {
+    assertThat(table.operations().current().formatVersion())
+        .isEqualTo(TableMetadata.MIN_FORMAT_VERSION_ROW_LINEAGE);
+
     table.newAppend().appendFile(FILE_A).commit();
 
     Snapshot appendSnapshot = table.currentSnapshot();
@@ -822,20 +825,26 @@ public class TestRowLineageAssignment {
         DataFiles.builder(PartitionSpec.unpartitioned()).copy(FILE_A).withFirstRowId(0L).build();
     OutputFile manifestOutput =
         table.io().newOutputFile(new File(location, "rewrite-manifest.avro").getAbsolutePath());
+    long unassignedManifestSnapshotId = -1L;
+    // A manifest snapshot ID of -1, not disabled snapshot ID inheritance, forces addManifest to
+    // copy this transient rewrite manifest.
     ManifestWriter<DataFile> writer =
         ManifestFiles.write(
             table.operations().current().formatVersion(),
             PartitionSpec.unpartitioned(),
             manifestOutput,
-            -1L);
+            unassignedManifestSnapshotId);
     try (ManifestWriter<DataFile> closeableWriter = writer) {
       closeableWriter.existing(
           fileWithRowId, appendSnapshot.snapshotId(), appendSnapshot.sequenceNumber(), null);
     }
 
     ManifestFile rewriteManifest = writer.toManifestFile();
+    assertThat(rewriteManifest.hasAddedFiles()).isFalse();
+    assertThat(rewriteManifest.hasExistingFiles()).isTrue();
+    assertThat(rewriteManifest.hasDeletedFiles()).isFalse();
     assertThat(rewriteManifest.firstRowId()).isNull();
-    assertThat(rewriteManifest.snapshotId()).isEqualTo(-1L);
+    assertThat(rewriteManifest.snapshotId()).isEqualTo(unassignedManifestSnapshotId);
 
     try (ManifestReader<DataFile> reader =
         ManifestFiles.read(rewriteManifest, table.io(), table.specs(), false /* isCommitted */)) {


### PR DESCRIPTION
### Summary
Fix a defensive row-lineage preservation issue related to [apache/iceberg#16263](https://github.com/apache/iceberg/pull/16263).

That PR fixed `first_row_id` carry-over for EXISTING entries during manifest merge. This PR covers a narrower direct API case: `RewriteManifests.addManifest` accepts a transient v3 rewrite manifest with manifest `snapshotId=-1`, null manifest-level `first_row_id`, and EXISTING data files that already have valid file-level `first_row_id` values.

This does not appear to be the normal built-in v3 rewrite-manifests path. Spark rewrite manifests writes new v3 manifests with `snapshotId=null`, which can inherit the commit snapshot ID, and core `rewriteManifests().clusterBy(...)` writes manifests using the operation snapshot ID. The `snapshotId=-1` case is for callers that directly provide a rewrite manifest to `RewriteManifests.addManifest`.

Previously, `ManifestFiles.copyRewriteManifest` read that manifest with committed-manifest semantics. `ManifestReader` then treated the null manifest-level `first_row_id` like committed pre-v3 metadata and cleared file-level row IDs, causing unchanged data files to receive new row IDs on commit.

### Fix
Read manifests copied by `copyRewriteManifest` as uncommitted (`isCommitted=false`) so EXISTING file-level `first_row_id` values are preserved.

### Validation
- Added a regression test for direct `RewriteManifests.addManifest` with a v3 transient rewrite manifest whose manifest snapshot ID is `-1`.
- Reproduced without the fix: expected `first_row_id=0L`, got `125L`.
- Passed: `./gradlew :iceberg-core:test --tests org.apache.iceberg.TestRowLineageAssignment.testRewriteManifestsAddManifestPreservesExistingFileFirstRowIds`

### Scope
Core defensive API correctness for accepted direct `addManifest` input. This is not claiming a normal Spark/core v3 rewrite-manifests action produces `snapshotId=-1`. Spark rewrite-manifest carry-over is separate and covered by [apache/iceberg#16699](https://github.com/apache/iceberg/pull/16699).
